### PR TITLE
修改 Input.js

### DIFF
--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -953,7 +953,7 @@ class WitCatInput {
 	 */
 	whatinput() {
 		if (document.activeElement !== null && document.activeElement.className === "WitCatInput") {
-			return document.activeElement.id.split("WitCatInput")[1];
+			return this._getWitCatID(document.activeElement);
 		}
 		else {
 			return "";
@@ -1173,7 +1173,7 @@ class WitCatInput {
 	 * @param {SCarg} args.text 属性值
 	 */
 	setinput(args) {
-		let search = document.getElementById("WitCatInput" + args.id);
+		let search = this._findWitCatInput(String(args.id));
 		if (search !== null) {
 			let sstyle = search.style;
 			let x, y, width, height, opacity;
@@ -1265,7 +1265,7 @@ class WitCatInput {
 	 * @param {SCarg} args.read 能否修改
 	 */
 	setread(args) {
-		let search = document.getElementById("WitCatInput" + args.id);
+		let search = this._findWitCatInput(String(args.id));
 		if (search !== null) {
 			if (args.read === "eb") {
 				search.disabled = false;
@@ -1283,7 +1283,7 @@ class WitCatInput {
 	 * @param {SCarg} args.read 是密码框 "test"|"password"
 	 */
 	password(args) {
-		let search = document.getElementById("WitCatInput" + args.id);
+		let search = this._findWitCatInput(String(args.id));
 		if (search !== null) {
 			search.type = args.read;
 		}
@@ -1380,10 +1380,7 @@ class WitCatInput {
 						return;
 					}
 					for (let searchi of Array.from(search)) {
-						const searchid = searchi.id.split("WitCatInput")[1];
-						if (searchid === undefined) {
-							continue;
-						}
+						const searchid = this._getWitCatID(searchi);
 						const fontsize = this.inputFontSize[searchid];
 						if (fontsize === undefined) {
 							continue;
@@ -1406,6 +1403,9 @@ class WitCatInput {
 		}
 	}
 
+	/**
+	 * 添加键盘鼠标事件
+	 */
 	_addevent() {
 		if (this.canvas === null || this.inputParent === null) {
 			return;
@@ -1432,6 +1432,40 @@ class WitCatInput {
 			}, 30);
 		}, {capture: true});
 	}
+
+	/**
+	 * 获取指定元素的 WitCatInput ID
+	 * @param {Element} element 元素
+	 * @returns {string} 元素 ID 去掉 WitCatInput 后的部分，如果没有，返回 ""
+	 */
+	_getWitCatID(element){
+		const match = /^WitCatInput(.*)$/.exec(element.id);
+		if (match === null || match[1] === undefined) {
+			console.warn("Input.js: 无法获取 WitCatInput ID: ", element);
+			return "";
+		}
+		return match[1];
+	}
+
+	/**
+	 * 获取指定 WitCatInput ID 的元素
+	 * @param {string} witcatID 元素
+	 * @returns {HTMLInputElement | HTMLTextAreaElement | null} 获取的元素，或者 null
+	 */
+	_findWitCatInput(witcatID){
+		const search = document.getElementById("WitCatInput" + witcatID);
+		if (search === null) {
+			console.warn("Input.js: 找不到 ID", witcatID);
+			return null;
+		}
+		if (search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement) {
+			return search;
+		}
+		console.warn("Input.js: 元素不是 <input> 或者 <textarea>");
+		return null;
+	}
+
+
 }
 
 window.tempExt = {

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -888,7 +888,7 @@ class WitCatInput {
 		sstyle.top = `${y}%`;
 		sstyle.width = `${width}%`;
 		sstyle.height = `${height}%`;
-		sstyle.fontSize = `${this.adaptive ? (Number(this.canvas.style.width.split("px")[0]) / 360) * Number(args.size) : Number(args.size)}px`;
+		sstyle.fontSize = `${this.adaptive ? (parseFloat(this.canvas.style.width) / 360) * Number(args.size) : Number(args.size)}px`;
 		sstyle.resize = "none";
 		sstyle.color = String(args.color);
 		sstyle.opacity = "1";
@@ -1003,7 +1003,7 @@ class WitCatInput {
 		if (this.canvas === null) {
 			return 0;
 		}
-		return Number(this.canvas.style.width.split("px")[0]) / 360 * Number(args.size);
+		return parseFloat(this.canvas.style.width) / 360 * Number(args.size);
 	}
 
 	/**
@@ -1038,14 +1038,14 @@ class WitCatInput {
 		}
 		switch (type) {
 			case "X":
-				return (Number(element.style.left.split("%")[0]) / 100) * this.runtime.stageWidth;
+				return parseFloat(element.style.left) / 100 * this.runtime.stageWidth;
 			// 理论上需要加break;，但是前面已经return了
 			case "Y":
-				return (Number(element.style.top.split("%")[0]) / 100) * this.runtime.stageHeight;
+				return parseFloat(element.style.top) / 100 * this.runtime.stageHeight;
 			case "width":
-				return (Number(element.style.width.split("%")[0]) / 100) * this.runtime.stageWidth;
+				return parseFloat(element.style.width) / 100 * this.runtime.stageWidth;
 			case "height":
-				return (Number(element.style.height.split("%")[0]) / 100) * this.runtime.stageHeight;
+				return parseFloat(element.style.height) / 100 * this.runtime.stageHeight;
 			case "content":
 				return element.value;
 			case "color":
@@ -1053,7 +1053,7 @@ class WitCatInput {
 			case "prompt":
 				return element.placeholder;
 			case "font-size":
-				return element.style.fontSize.split("px")[0];
+				return parseFloat(element.style.fontSize);
 			case "ID":
 				// 直接上正则，可以处理类似“WitCatInput123WitCatInput456”这样包含“WitCatInput”的奇葩ID
 				{
@@ -1189,13 +1189,13 @@ class WitCatInput {
 					sstyle.top = y + "%";
 					break;
 				case "width":
-					x = Number(sstyle.left.split("%")[0]) / 100 * this.runtime.stageWidth;
+					x = parseFloat(sstyle.left) / 100 * this.runtime.stageWidth;
 					width = this._clamp(Number(args.text), 0, this.runtime.stageWidth - x);
 					width = (width / this.runtime.stageWidth) * 100;
 					sstyle.width = Number(width) + "%";
 					break;
 				case "height":
-					y = Number(sstyle.top.split("%")[0]) / 100 * this.runtime.stageHeight;
+					y = parseFloat(sstyle.top) / 100 * this.runtime.stageHeight;
 					height = this._clamp(Number(args.text), 0, this.runtime.stageHeight - y);
 					height = (height / this.runtime.stageHeight) * 100;
 					sstyle.height = Number(height) + "%";
@@ -1388,7 +1388,7 @@ class WitCatInput {
 						if (fontsize === undefined) {
 							continue;
 						}
-						searchi.style.fontSize = Number(this.canvas.style.width.split("px")[0]) / 360 * fontsize + "px";
+						searchi.style.fontSize = parseFloat(this.canvas.style.width) / 360 * fontsize + "px";
 					}
 				};
 				this.observer = new MutationObserver(callback);

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -62,16 +62,16 @@ class WitCatInput {
 		 */
 		this.inputParent = null;
 
-		// 这里应该有一种方法能够通过 runtime 获得 Canvas
-		let allcvs = Array.from(document.getElementsByTagName("canvas"));
-		for (const cvs of allcvs) {
-			// 筛选出真正的绘画 Canvas
-			if (cvs.className === "") {
-				this.canvas = cvs;
-				this.inputParent = cvs.parentElement;
-				break;
+		try {
+			const canvas = runtime.renderer.canvas;
+			if (canvas instanceof HTMLCanvasElement) {
+				this.canvas = canvas;
+				this.inputParent = canvas.parentElement;
 			}
+		} catch(err) {
+			console.error(err);
 		}
+
 		if (this.canvas === null || this.inputParent === null) {
 			alert("当前页面不支持文本框，请前往作品详情页体验完整作品！");
 			// 注意：在提示之后，扩展仍然在运行。需要在后面引用 Canvas 的部分进行判断。

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -859,13 +859,17 @@ class WitCatInput {
 			search = null;
 		}
 		if (search === null) {
-			if (args.type !== "input" && args.type !== "textarea") {
+			// 标准下 input 和 textarea 都应该是小写，
+			// 但是菜单中的 textarea 是大写的。
+			// 为了兼容不能修改菜单数值，只能转换。
+			const argstype = String(args.type).toLowerCase();
+			if (argstype !== "input" && argstype !== "textarea") {
 				// 防止修改 JSON 注入
 				console.warn("Input.js: 类型应该是 input 或者 textarea");
 				return;
 			}
-			search = document.createElement(args.type);
-			// 条件修改只是为了通过类型检查
+			search = document.createElement(argstype);
+			// 只有 input 才有 type 属性，textarea 没有
 			if (search instanceof HTMLInputElement) {
 				search.type = "text";
 			}

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -942,8 +942,13 @@ class WitCatInput {
 		if (search !== null) {
 			search.focus();
 		}
-		else if (document.activeElement !== null && document.activeElement.className === "WitCatInput") {
-			document.activeElement.blur();
+		else {
+			const active = document.activeElement;
+			if (active !== null && active.className === "WitCatInput") {
+				if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+					active.blur();
+				}
+			}
 		}
 	}
 
@@ -1025,7 +1030,7 @@ class WitCatInput {
 				// 直接上正则，可以处理类似“WitCatInput123WitCatInput456”这样包含“WitCatInput”的奇葩ID
 				{
 					let match = /^WitCatInput(.*)$/.exec(element.id);
-					return match === null ? "" : match[1];
+					return match === null || match[1] === undefined ? "" : match[1];
 				}
 			case "rp":
 				return element.scrollTop;
@@ -1347,7 +1352,15 @@ class WitCatInput {
 						return;
 					}
 					for (let searchi of Array.from(search)) {
-						searchi.style.fontSize = ((Number(this.canvas.style.width.split("px")[0]) / 360) * inputFontSize[searchi.id.split("WitCatInput")[1]]) + "px";
+						const searchid = searchi.id.split("WitCatInput")[1];
+						if (searchid === undefined) {
+							continue;
+						}
+						const fontsize = inputFontSize[searchid];
+						if (fontsize === undefined) {
+							continue;
+						}
+						searchi.style.fontSize = Number(this.canvas.style.width.split("px")[0]) / 360 * fontsize + "px";
 					}
 				};
 				observer = new MutationObserver(callback);

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -1285,7 +1285,11 @@ class WitCatInput {
 	password(args) {
 		let search = this._findWitCatInput(String(args.id));
 		if (search !== null) {
-			search.type = args.read;
+			if (search instanceof HTMLTextAreaElement) {
+				console.warn("Input.js: 多行文本框无法设为密码框");
+				return;
+			}
+			search.type = String(args.read);
 		}
 	}
 

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -6,12 +6,21 @@ const witcat_input_icon = "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHh
 
 const witcat_input_extensionId = "WitCatInput";
 
+/** @typedef {string|number} SCarg 来自Scratch圆形框的参数，虽然这个框可能只能输入数字，但是可以放入变量，因此有可能获得数字和文本，需要同时处理 */
+
+/** @type {{[key: string]: true}} */
 let keypress = {};
 let lastKey = "", MouseWheel = 0;
+/** @type {number} */
 let timer;
-let inputFontSize = {}, adaptive = false, observer;
+/** @type {{[key: string]: number}} */
+let inputFontSize = {};
+let adaptive = false;
+/** @type {MutationObserver} */
+let observer;
 
 //找渲染cvs
+/** @type {HTMLCanvasElement} */
 let cvs = document.getElementsByTagName("canvas")[0];
 if (cvs === null) {
 	alert("当前页面不支持输入框，请前往作品详情页体验完整作品！");
@@ -154,6 +163,11 @@ class WitCatInput {
 		})
 	}
 
+	/**
+	 * 翻译
+	 * @param {string} id
+	 * @returns {string}
+	 */
 	formatMessage(id) {
 		return this._formatMessage({
 			id,
@@ -733,7 +747,11 @@ class WitCatInput {
 			}
 		};
 	}
-	//打开教程
+
+	/**
+	 * 打开教程
+	 * @returns {void}
+	 */
 	docs() {
 		let a = document.createElement('a');
 		a.href = "https://www.ccw.site/post/6153a7a6-05fb-462e-b785-b97700b12bc2";
@@ -754,7 +772,20 @@ class WitCatInput {
 		// return isNaN(x) ? min : Math.min(max, Math.max(min, x));
 	}
 
-	//设置或创建文本框
+	/**
+	 * 设置或创建文本框
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.type 文本框类型 "input"|"textarea"
+	 * @param {SCarg} args.x 左上角x
+	 * @param {SCarg} args.y 左上角y
+	 * @param {SCarg} args.width 宽度
+	 * @param {SCarg} args.height 高度
+	 * @param {SCarg} args.text 初始文本
+	 * @param {SCarg} args.color 文字颜色
+	 * @param {SCarg} args.texts 提示文本
+	 * @param {SCarg} args.size 文字大小 
+	 */
 	createinput(args) {
 		let x = Number(args.x);
 		let y = Number(args.y);
@@ -811,34 +842,56 @@ class WitCatInput {
 
 		inputFontSize[args.id] = args.size;
 	}
-	//删除文本框
+
+	/**
+	 * 删除文本框
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框id
+	 */
 	deleteinput(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
 			cvs.parentNode.removeChild(search);
 		}
 	}
-	//获取文本框内容
+
+	/**
+	 * 获取文本框内容
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框id
+	 * @param {SCarg} args.type 内容类型
+	 * @return {SCarg}
+	 */
 	getinput(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		return search === null ? "" : this._getattrib(search, args.type);
 	}
-	//焦点判断
+
+	/**
+	 * 焦点判断
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @returns {boolean}
+	 */
 	isinput(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
 			if (search === document.activeElement) {
-				return (true);
+				return true;
 			}
 			else {
-				return (false);
+				return false;
 			}
 		}
 		else {
-			return (false);
+			return false;
 		}
 	}
-	//焦点位置
+
+	/**
+	 * 焦点位置
+	 * @returns {string} 文本框 ID
+	 */
 	whatinput() {
 		if (document.activeElement.className === "WitCatInput") {
 			return document.activeElement.id.split("WitCatInput")[1];
@@ -847,7 +900,12 @@ class WitCatInput {
 			return "";
 		}
 	}
-	//焦点获取
+
+	/**
+	 * 焦点获取
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 */
 	nowinput(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
@@ -857,7 +915,10 @@ class WitCatInput {
 			document.activeElement.blur();
 		}
 	}
-	//删除所有文本框
+
+	/**
+	 * 删除所有文本框
+	 */
 	deleteallinput() {
 		let search = document.getElementsByClassName("WitCatInput");
 		let i = 0;
@@ -865,11 +926,23 @@ class WitCatInput {
 			search[i].parentNode.removeChild(search[i]);
 		}
 	}
-	//计算坐标
+
+	/**
+	 * 计算文字大小
+	 * @param {object} args
+	 * @param {SCarg} args.size Scratch 文字大小
+	 */
 	compute(args) {
 		return (Number(cvs.style.width.split("px")[0]) / 360) * args.size;
 	}
-	//获取指定编号的文本框属性
+
+	/**
+	 * 获取指定编号的文本框属性
+	 * @param {object} args
+	 * @param {SCarg} args.num 文本框序号
+	 * @param {SCarg} args.type 属性类型
+	 * @returns {SCarg}
+	 */
 	number(args) {
 		let searchall = document.getElementsByClassName("WitCatInput");
 		let index = Number(args.num);
@@ -970,12 +1043,22 @@ class WitCatInput {
 				return "";
 		}
 	}
-	//文本框数量
+
+	/**
+	 * 文本框数量
+	 * @returns {number}
+	 */
 	numbers() {
 		let search = document.getElementsByClassName("WitCatInput");
 		return search.length;
 	}
-	//按键检测
+
+	/**
+	 * 按键检测
+	 * @param {object} args
+	 * @param {SCarg} args.type 按键类型，用逗号分隔
+	 * @returns {boolean}
+	 */
 	key(args) {
 		let key = args.type.split(",");
 		for (const item of key) {
@@ -985,19 +1068,40 @@ class WitCatInput {
 		}
 		return true;
 	}
-	//按键检测
+
+	/**
+	 * 按键检测(帽子积木)
+	 * @param {object} args
+	 * @param {SCarg} args.type 按键类型，用逗号分隔
+	 * @returns {boolean}
+	 */
 	keys(args) {
 		return this.key(args);
 	}
-	//上次按下的键
+
+	/**
+	 * 上次按下的键
+	 * @returns {string}
+	 */
 	lastkey() {
 		return lastKey;
 	}
-	//鼠标滚轮
+
+	/**
+	 * 鼠标滚轮速度
+	 * @returns {number}
+	 */
 	mousewheel() {
 		return MouseWheel;
 	}
-	//设置文本框
+
+	/**
+	 * 设置文本框
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.type 属性类型
+	 * @param {SCarg} args.text 属性值
+	 */
 	setinput(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
@@ -1083,7 +1187,13 @@ class WitCatInput {
 			}
 		}
 	}
-	//设置状态
+
+	/**
+	 * 设置是否可修改
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.read 能否修改
+	 */
 	setread(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
@@ -1095,18 +1205,35 @@ class WitCatInput {
 			}
 		}
 	}
-	//设置文本框的type
+
+	/**
+	 * 设置文本框是否为密码框
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.read 是密码框 "test"|"password"
+	 */
 	password(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
 			search.type = args.read;
 		}
 	}
-	//获取按下的按键
+
+	/**
+	 * 获取按下的按键
+	 * @returns {string}
+	 */
 	keypress() {
 		return JSON.stringify(Object.keys(keypress));
 	}
-	//设置字体
+
+	/**
+	 * 设置字体
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.name 字体名
+	 * @param {SCarg} args.text 字体链接
+	 */
 	setfont(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
@@ -1125,25 +1252,51 @@ class WitCatInput {
 			xhr.send();
 		}
 	}
-	//设置对齐方式
+
+	/**
+	 * 设置对齐方式
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.read 对齐方式 "left"|"center"|"right"
+	 */
 	textalign(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
 			search.style.textAlign = args.read;
 		}
 	}
-	//设置文本框字体粗细
+
+	/**
+	 * 设置文本框字体粗细
+	 * @param {object} args
+	 * @param {SCarg} args.id 文本框 ID
+	 * @param {SCarg} args.text 字体粗细
+	 */
 	fontweight(args) {
 		let search = document.getElementById("WitCatInput" + args.id);
 		if (search !== null) {
 			search.style.fontWeight = args.text;
 		}
 	}
-	//创建阴影
+
+	/**
+	 * 创建阴影
+	 * @param {object} args
+	 * @param {SCarg} args.x 偏移x
+	 * @param {SCarg} args.y 偏移y
+	 * @param {SCarg} args.width 宽度
+	 * @param {SCarg} args.color 颜色
+	 * @returns {string}
+	 */
 	shadow(args) {
 		return `${args.x}px ${args.y}px ${args.width}px ${args.color}`
 	}
-	//设置字体自适应
+
+	/**
+	 * 设置字体自适应
+	 * @param {object} args
+	 * @param {SCarg} args.type
+	 */
 	fontadaptive(args) {
 		if (args.type == "true") {
 			if (!adaptive) {
@@ -1193,8 +1346,10 @@ window.tempExt = {
 	}
 };
 
-/* vim: set expandtab tabstop=2 shiftwidth=2: */
-//颜色转换
+/**
+ * 颜色转换
+ * @param {string} color
+ */
 function string_colorHex(color) {
 	// RGB颜色值的正则
 	var reg = /^(rgb|RGB)/;
@@ -1219,14 +1374,28 @@ function string_colorHex(color) {
 //键盘事件监听
 document.addEventListener("keydown", keydown);
 document.addEventListener("keyup", keyup);
+
+/**
+ * 按下键的处理
+ * @param {KeyboardEvent} event
+ */
 function keydown(event) {
 	keypress[event.code] = true;
 	lastKey = event.code;
 }
+
+/**
+ * 松开键的处理
+ * @param {KeyboardEvent} event
+ */
 function keyup(event) {
 	delete keypress[event.code];
 }
-//滚轮事件监听
+
+/**
+ * 滚轮事件监听
+ * @param {Event} e
+ */
 var scrollFunc = e => {
 	e = e || window.event;
 	if (e.wheelDelta) {  //判断浏览器IE，谷歌滑轮事件

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -65,8 +65,8 @@ class WitCatInput {
 		// 这里应该有一种方法能够通过 runtime 获得 Canvas
 		let allcvs = Array.from(document.getElementsByTagName("canvas"));
 		for (const cvs of allcvs) {
-			// 说句实话，我不知道原版的代码的这个判断想干什么
-			if (cvs.className !== "") {
+			// 筛选出真正的绘画 Canvas
+			if (cvs.className === "") {
 				this.canvas = cvs;
 				this.inputParent = cvs.parentElement;
 				break;

--- a/wit_cat/Input.js
+++ b/wit_cat/Input.js
@@ -11,8 +11,8 @@ const witcat_input_extensionId = "WitCatInput";
 /** @type {{[key: string]: true}} */
 let keypress = {};
 let lastKey = "", MouseWheel = 0;
-/** @type {number} */
-let timer;
+/** @type {number|undefined} */
+let timer = undefined;
 /** @type {{[key: string]: number}} */
 let inputFontSize = {};
 let adaptive = false;
@@ -1394,23 +1394,18 @@ function keyup(event) {
 
 /**
  * 滚轮事件监听
- * @param {Event} e
+ * @param {WheelEvent} e
  */
-var scrollFunc = e => {
-	e = e || window.event;
-	if (e.wheelDelta) {  //判断浏览器IE，谷歌滑轮事件
-		MouseWheel = e.wheelDelta;
-	} else if (e.detail) {  //Firefox滑轮事件
-		MouseWheel = e.detail;
-	}
+function scrollFunc(e) {
+	// 注意这个负数……
+	// 目前的标准用法是使用 deltaY，但是 deltaY 的符号和 WheelDeltaY 相反。
+	// 为了和原有的行为一致，乘上 -3
+	// 在我的浏览器中 deltaY = WheelDeltaY / -3
+	MouseWheel = e.deltaY * -3;
 	clearTimeout(timer);
 	timer = setTimeout(() => {
 		MouseWheel = 0;
 	}, 30);
 };
 //给页面绑定滑轮滚动事件
-if (cvs.parentNode.addEventListener) { //火狐使用DOMMouseScroll绑定
-	cvs.parentNode.addEventListener('DOMMouseScroll', scrollFunc, false);
-}
-//其他浏览器直接绑定滚动事件
-cvs.parentNode.onmousewheel = scrollFunc;
+cvs.addEventListener('wheel', scrollFunc, {capture: true});


### PR DESCRIPTION
使用标准的 'wheel' 事件处理鼠标滚轮事件。  
删除兼容 IE 的代码（现在是 2023 年，很多 API 都统一了，CCW 构建的时候会做兼容转化，不需要复制粘贴十年前的教程里的兼容代码）  
把和扩展功能直接相关的全局变量/函数放到类内。  
完善类型检查（在 Scratch 扩展中不是设定输入框类型为数字/文本，输入的参数类型一定就是数字/文本，因为 Scratch 数字和文本都使用圆形表示。TurboWarp在优化的时候还会为了加速进行文本转数字）  
完善类型的另一个问题就是**部分变量的类型被限制**（例如关于 search 有判断元素是否是 input 或者 textarea 的判断，这是为了防止获取 WitCatInput+id 时意外获得奇怪的元素，也防止有人通过改作品 JSON 实现注入奇怪元素）  
使用 parseFloat 来处理 "20px" "50%" 这样的文本。不用 split[0]。  
把获取文本框 ID 的动作（从 id 中去掉前面的 WitCatInput）和查找指定 ID 的动作放到了两个独立的函数，可以方便之后优化。  
**直接使用 runtime 直接获取 cvs，大大增强稳定性**（这意味着处理 cvs 的代码更适合在类内）  
**多行文本框直接调为密码模式会直接出错影响作品运行，因为 textarea 的 type 属性不能修改**。于是多行文本框设为密码模式会在控制台输出警告并且不修改。